### PR TITLE
Simplify RecordStreamLambda payload handling

### DIFF
--- a/AyauPlay-Template.yaml
+++ b/AyauPlay-Template.yaml
@@ -1449,7 +1449,6 @@ Resources:
           import boto3
           import os
           import logging
-          import re
           import time
 
           logger = logging.getLogger()
@@ -1457,12 +1456,13 @@ Resources:
 
           redshift_data = boto3.client('redshift-data')
 
-          def run_statement(sql):
+          def run_statement(sql, parameters=None):
               response = redshift_data.execute_statement(
                   ClusterIdentifier=os.environ['REDSHIFT_CLUSTER_ID'],
                   Database=os.environ['REDSHIFT_DATABASE'],
                   DbUser=os.environ['REDSHIFT_DB_USER'],
-                  Sql=sql
+                  Sql=sql,
+                  Parameters=parameters or []
               )
 
               statement_id = response['Id']
@@ -1477,54 +1477,17 @@ Resources:
 
               return redshift_data.get_statement_result(Id=statement_id)
 
-          def parse_body(event_body):
-              def try_json_loads(payload):
-                  try:
-                      return json.loads(payload)
-                  except json.JSONDecodeError:
-                      # Handle common JavaScript-style objects without quoted keys
-                      # e.g., {song_uuid: "123", stream_duration: "00:04"}
-                      fixed_payload = re.sub(r'([,{\s])(\w+)\s*:', r'\1"\2":', payload)
-                      return json.loads(fixed_payload)
-
-              if isinstance(event_body, dict):
-                  return event_body
-              if not event_body:
-                  return {}
-
-              if isinstance(event_body, str):
-                  stripped = event_body.strip()
-                  if not stripped:
-                      return {}
-                  return try_json_loads(stripped)
-
-              return {}
-
-          def parse_duration(duration_value):
-              if duration_value is None:
-                  return 0
-
-              if isinstance(duration_value, (int, float)):
-                  return int(duration_value)
-
-              if isinstance(duration_value, str):
-                  duration_value = duration_value.strip()
-                  if duration_value.isdigit():
-                      return int(duration_value)
-
-                  # Handle MM:SS inputs like "00:04"
-                  if ':' in duration_value:
-                      parts = duration_value.split(':')
-                      if len(parts) == 2 and all(p.isdigit() for p in parts):
-                          minutes, seconds = parts
-                          return int(minutes) * 60 + int(seconds)
-
-              raise ValueError('Invalid stream_duration format')
+          def get_user_id(event):
+              authorizer = event.get('requestContext', {}).get('authorizer', {})
+              claims = authorizer.get('claims', {}) or {}
+              user_id = claims.get('sub') or authorizer.get('principalId')
+              return user_id
 
           def handler(event, context):
               try:
+                  body_raw = event.get('body')
                   try:
-                      body = parse_body(event.get('body'))
+                      body = body_raw if isinstance(body_raw, dict) else json.loads(body_raw or '{}')
                   except json.JSONDecodeError:
                       return {
                           'statusCode': 400,
@@ -1536,26 +1499,10 @@ Resources:
                           'body': json.dumps('Invalid JSON payload')
                       }
 
-                  song_uuid = body.get('song_uuid') or body.get('uuid') or body.get('song_id')
+                  song_uuid = body.get('song_uuid')
+                  stream_duration = body.get('stream_duration')
 
-                  try:
-                      stream_duration = parse_duration(body.get('stream_duration', 0))
-                  except ValueError as parse_error:
-                      return {
-                          'statusCode': 400,
-                          'headers': {
-                              "Access-Control-Allow-Origin": "*",
-                              "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
-                              "Access-Control-Allow-Methods": "OPTIONS,POST"
-                          },
-                          'body': json.dumps(str(parse_error))
-                      }
-
-                  # Extract user information from Cognito claims, fall back to request body
-                  claims = event.get('requestContext', {}).get('authorizer', {}).get('claims', {})
-                  user_id = claims.get('sub') or body.get('user_id')
-
-                  if not song_uuid:
+                  if song_uuid is None:
                       return {
                           'statusCode': 400,
                           'headers': {
@@ -1565,6 +1512,41 @@ Resources:
                           },
                           'body': json.dumps('song_uuid is required')
                       }
+
+                  if stream_duration is None:
+                      return {
+                          'statusCode': 400,
+                          'headers': {
+                              "Access-Control-Allow-Origin": "*",
+                              "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+                              "Access-Control-Allow-Methods": "OPTIONS,POST"
+                          },
+                          'body': json.dumps('stream_duration is required')
+                      }
+
+                  if not isinstance(song_uuid, str):
+                      return {
+                          'statusCode': 400,
+                          'headers': {
+                              "Access-Control-Allow-Origin": "*",
+                              "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+                              "Access-Control-Allow-Methods": "OPTIONS,POST"
+                          },
+                          'body': json.dumps('song_uuid must be a string')
+                      }
+
+                  if not isinstance(stream_duration, int):
+                      return {
+                          'statusCode': 400,
+                          'headers': {
+                              "Access-Control-Allow-Origin": "*",
+                              "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+                              "Access-Control-Allow-Methods": "OPTIONS,POST"
+                          },
+                          'body': json.dumps('stream_duration must be an integer (seconds)')
+                      }
+
+                  user_id = get_user_id(event)
 
                   if user_id is None:
                       return {
@@ -1577,11 +1559,14 @@ Resources:
                           'body': json.dumps('Unauthorized')
                       }
 
-                  # Fetch the database primary key for the provided song UUID
-                  get_song_sql = f"SELECT song_id FROM songs WHERE uuid = '{song_uuid}' LIMIT 1;"
-                  result = run_statement(get_song_sql)
+                  # Fetch the database primary key for the provided song UUID using a parameterized query
+                  get_song_sql = "SELECT song_id FROM songs WHERE uuid = :song_uuid LIMIT 1;"
+                  song_result = run_statement(
+                      get_song_sql,
+                      parameters=[{"name": "song_uuid", "value": {"stringValue": song_uuid}}]
+                  )
 
-                  records = result.get('Records', [])
+                  records = song_result.get('Records', [])
                   if not records:
                       return {
                           'statusCode': 404,
@@ -1593,14 +1578,21 @@ Resources:
                           'body': json.dumps('Song not found')
                       }
 
-                  song_id = records[0][0]['longValue']
+                  song_id = records[0][0].get('longValue') or records[0][0].get('stringValue')
 
-                  sql = f"""
-                  INSERT INTO stream_analytics (song_id, user_id, stream_duration)
-                  VALUES ({song_id}, '{user_id}', {stream_duration});
-                  """
+                  insert_sql = (
+                      "INSERT INTO stream_analytics (song_id, user_id, stream_duration) "
+                      "VALUES (:song_id, :user_id, :stream_duration);"
+                  )
 
-                  run_statement(sql)
+                  run_statement(
+                      insert_sql,
+                      parameters=[
+                          {"name": "song_id", "value": {"longValue": int(song_id)}},
+                          {"name": "user_id", "value": {"stringValue": user_id}},
+                          {"name": "stream_duration", "value": {"longValue": int(stream_duration)}},
+                      ],
+                  )
 
                   return {
                       'statusCode': 200,
@@ -1623,6 +1615,7 @@ Resources:
                       'body': json.dumps(f"Error recording stream: {str(e)}")
                   }
       Runtime: python3.10
+      Timeout: 10
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment


### PR DESCRIPTION
## Summary
- simplify the RecordStreamLambda to accept JSON payloads with string song_uuid and integer stream_duration without extra format parsing
- add basic validation for required fields and types while continuing to use authorizer-derived user context for inserts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69304e76ee8083288d2a9b7c1d4ddfbf)